### PR TITLE
Implementation of issue 2573

### DIFF
--- a/tg-au/content/tg-au-externallyGovernedCodeLists.adoc
+++ b/tg-au/content/tg-au-externallyGovernedCodeLists.adoc
@@ -1,0 +1,49 @@
+===Externally governed code lists
+
+The externally governed code lists included in this application schema are specified in the tables in this section.
+
+====Governance and authoritative source
+
+|=== 
+
+| Code list | Governance  | Authoritative Source (incl. version and relevant subset, where applicable)
+
+| EUCountryCode | Publications Office of the European Union | European Union Interinstitutional style guide, Luxembourg, Publications Office of the European Union
+
+|=== 
+
+====Availability
+
+|=== 
+
+| Code list | Availability  | Format
+
+| EUCountryCode | http://publications.europa.eu/code/[two-letter country code]/[two-letter country code]-5000600.htm | HTML
+
+| EUCountryCode | http://publications.europa.eu/mdr/resource/authority/country/html/countries-[three-letter country code].html | HTML
+
+| EUCountryCode | http://publications.europa.eu/mdr/resource/authority/country/xml/countries.xml | XML
+
+| EUCountryCode | http://publications.europa.eu/mdr/resource/authority/country/skos/countries-skos.rdf | SKOS
+
+| EUCountryCode | http://publications.europa.eu/mdr/resource/authority/country/skos-ap-eu/countries-skos-ap-act.rdf | SKOS-AP-EU
+
+|=== 
+
+====Rules for code list values
+
+|=== 
+
+| Code list | Identifiers  | Examples
+
+| EUCountryCode | Append the upper-case two-letter code in the ―Code‖ column of Annex A6 to the URI prefix http://inspire.ec.europa.eu/codeList/CountryCode/ | European Union http://inspire.ec.europa.eu/codeList/CountryCode/DE, http://inspire.ec.europa.eu/codeList/CountryCode/UK
+
+|=== 
+
+|=== 
+
+| Code list | Labels  | Format
+
+| EUCountryCode | Use the name in the ―Country/territory‖ column of Annex A6 in any official EU language as the label. | United Kingdom (English label for UK), Deutschland‖ (German label for DE)
+
+|=== 

--- a/tg-au/tg-au-index-dataContentAndStructure.adoc
+++ b/tg-au/tg-au-index-dataContentAndStructure.adoc
@@ -24,6 +24,8 @@ include::../tg-template/tg-dataContentAndStructure.adoc[tags=tg-temporalityRepre
 
 include::content/tg-au-dataContentAndStructure.adoc[tags=tg-au-applicationSchemas]
 
+include::content/tg-au-externallyGovernedCodeLists.adoc[]
+
 include::content/tg-au-dataContentAndStructure.adoc[tags=tg-au-applicationSchemaAU]
 
 include::content/tg-au-dataContentAndStructure.adoc[tags=tg-au-featureCatalogue]


### PR DESCRIPTION
The INSPIRE CountryCode code list does not contain any value, instead it refers to an external link, http://epp.eurostat.ec.europa.eu/statistics_explained/index.php/Glossary:European_Union_(EU), where you can search for the country codes. According to the Implementing Rules, which refer (Sec. 4.2) to the Interinstitutional style guide published by the Publications Office of the European Union, the External Reference Link for the CountryCode code list should be http://publications.europa.eu/code/en/en-5000600.htm , a more useful link directly providing the ‘Country and territory codes’ table.

In the TG add additional section "Externally governed code lists" as in framework document "INSPIRE DS template v3.0rc3" (section 5.3.3)